### PR TITLE
Make Neo & Forge builds cross-compat

### DIFF
--- a/forge/src/main/java/dev/wuffs/bcc/mixin/ServerStatusPingerMixin.java
+++ b/forge/src/main/java/dev/wuffs/bcc/mixin/ServerStatusPingerMixin.java
@@ -1,5 +1,6 @@
 package dev.wuffs.bcc.mixin;
 
+import dev.wuffs.bcc.Constants;
 import dev.wuffs.bcc.contract.ServerDataExtension;
 import dev.wuffs.bcc.data.BetterStatus;
 import net.minecraft.client.Minecraft;
@@ -13,7 +14,7 @@ import java.lang.reflect.Field;
 
 @Mixin(targets = "net/minecraft/client/multiplayer/ServerStatusPinger$1")
 public class ServerStatusPingerMixin {
-    private static final Field SERVER_DATA_FIELD;
+    private static Field SERVER_DATA_FIELD;
 
     // Credit to https://github.com/Aizistral-Studios/No-Chat-Reports/blob/1.20-Unified/forge/src/main/java/com/aizistral/nochatreports/forge/mixins/client/MixinServerStatusPinger%241.java
     static {
@@ -21,18 +22,26 @@ public class ServerStatusPingerMixin {
         try {
             Class<?> pinger = Class.forName("net.minecraft.client.multiplayer.ServerStatusPinger$1");
 
-            SERVER_DATA_FIELD = pinger.getDeclaredField("val$p_105460_");
-            SERVER_DATA_FIELD.setAccessible(true);
-        } catch (Exception ex) {
-            Error error = new Error("Reflection failed in MixinServerStatusPinger$1!", ex);
-
-            Minecraft.getInstance().execute(() -> {
-                throw error;
-            });
-
-            throw error;
+            SERVER_DATA_FIELD = getPingerField(pinger, "val$p_105460_");
+            if(SERVER_DATA_FIELD == null){
+                SERVER_DATA_FIELD = getPingerField(pinger, "val$pServer");
+            }
+            if(SERVER_DATA_FIELD != null) {
+                SERVER_DATA_FIELD.setAccessible(true);
+            }
+        } catch(ClassNotFoundException ex){
+            Constants.LOG.error("[Better Compat Pinger Mixin]: " + ex.getMessage());
         }
     }
+
+    private static Field getPingerField(Class<?> pingerClazz, String fieldName){
+        try {
+            return pingerClazz.getDeclaredField(fieldName);
+        } catch(NoSuchFieldException ex){
+            return null;
+        }
+    }
+
 
     @Inject(
             method = "handleStatusResponse(Lnet/minecraft/network/protocol/status/ClientboundStatusResponsePacket;)V",

--- a/neo/src/main/java/dev/wuffs/bcc/mixin/ServerStatusPingerMixin.java
+++ b/neo/src/main/java/dev/wuffs/bcc/mixin/ServerStatusPingerMixin.java
@@ -22,10 +22,23 @@ public class ServerStatusPingerMixin {
         try {
             Class<?> pinger = Class.forName("net.minecraft.client.multiplayer.ServerStatusPinger$1");
 
-            SERVER_DATA_FIELD = pinger.getDeclaredField("val$pServer");
-            SERVER_DATA_FIELD.setAccessible(true);
-        } catch (Exception ex) {
+            SERVER_DATA_FIELD = getPingerField(pinger, "val$pServer");
+            if(SERVER_DATA_FIELD == null){
+                SERVER_DATA_FIELD = getPingerField(pinger, "val$p_105460_");
+            }
+            if(SERVER_DATA_FIELD != null) {
+                SERVER_DATA_FIELD.setAccessible(true);
+            }
+        } catch(ClassNotFoundException ex){
             Constants.LOG.error("[Better Compat Pinger Mixin]: " + ex.getMessage());
+        }
+    }
+
+    private static Field getPingerField(Class<?> pingerClazz, String fieldName){
+        try {
+            return pingerClazz.getDeclaredField(fieldName);
+        } catch(NoSuchFieldException ex){
+            return null;
         }
     }
 


### PR DESCRIPTION
Check both known names for the serverData field in both forge and NeoForge so that they are cross compatible. Also means that if NeoForge fixes this pollution of the jar that no new version will be required.
